### PR TITLE
Use 60s Sentry healthcheck pings

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,8 +120,8 @@ async def health_endpoint(_request):
         success = True
         
     current_time = time()
-    # Ping Sentry at least every minute. Using a 30s buffer to be safe.
-    if IS_SENTRY_ENABLED and current_time - state["sentry_cron_last_ping_time"] > 50:
+    # Ping Sentry at least every minute.
+    if IS_SENTRY_ENABLED and current_time - state["sentry_cron_last_ping_time"] >= 60:
         state["sentry_cron_last_ping_time"] = current_time
         capture_checkin(
             monitor_slug='discord-provisioner-bot',


### PR DESCRIPTION
We are still hitting rate limits. This PR reduces the number of pings further.

<img width="2672" alt="image" src="https://github.com/user-attachments/assets/c35edc38-d130-4bfd-a0af-a9f3a3cf7b76">

https://watonomous.sentry.io/issues/5651029255/?environment=wato-aks1&statsPeriod=1h
